### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 # Automated Website Analysis System
 
 ## Project Overview
-Development of an automated system capable of parsing website sitemaps, using browser-use for automated browser operations to inspect web pages, and generating analysis reports by analyzing screenshots with GPT.
-Focus on implementing core functional modules, testing is not required.
-Docker-related files are to be created, but container creation and execution will be handled manually by the developer.
+This project builds an automated system that parses website sitemaps, uses browser-use to visit pages automatically, and analyzes screenshots with GPT to produce reports.
+The focus is on building the core modules; no tests are required.
+Docker files are provided, but you need to build and run containers manually.
 
 ## Quick Start (Local Development)
 ```bash
@@ -64,7 +64,7 @@ python src/main.py --url https://example.com
 - Supports nested sitemaps and sitemap indexes.
 - Filters and categorizes different types of pages.
 
-### Module 2: Browser-Use Automation Detector (`browser_automation.py`)
+### Module 2: Browser-Use Automation Module (`browser_automation.py`)
 - Uses browser-use (based on Playwright) for browser automation.
 - Performs page screenshots and basic interaction tests.
 - Collects page performance and usability data.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,7 +14,7 @@ cd website_analyzer
 # 2. 建立虛擬環境
 python3 -m venv venv
 source venv/bin/activate  # Linux/Mac
-# 或 `venv\Scriptsctivate`  # Windows
+# 或 `venv\Scripts\activate`  # Windows
 
 # 3. 安裝依賴
 pip install -r requirements.txt
@@ -219,4 +219,3 @@ DB_PASSWORD=secure_password
 
 ## 授權
 本專案採用 MIT 授權 - 詳情請參閱 [LICENSE](LICENSE) 檔案。
-```


### PR DESCRIPTION
## Summary
- polish project overview in README
- fix a typo in the Chinese README
- remove stray markdown fence
- rename a section header

## Testing
- `python website_analyzer/main.py --help` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68428ac72e3c8333bdb730dd90750474